### PR TITLE
em-websocket compatible request path inclues query params

### DIFF
--- a/lib/rack/websocket/handler/thin.rb
+++ b/lib/rack/websocket/handler/thin.rb
@@ -38,7 +38,7 @@ module Rack
         # this probably should be moved to Base in future
         def request_from_env(env)
           request = {}
-          request['path']   = env['REQUEST_PATH'].to_s
+          request['path']   = env['REQUEST_URI'].to_s
           request['method'] = env['REQUEST_METHOD']
           request['query']  = env['QUERY_STRING'].to_s
           request['Body']   = env['rack.input'].read


### PR DESCRIPTION
When connecting with Safari on both OSX and iOS to an endpoint with URL params, the handshake fails because the location param passed back in the upgrade header doesn't include the full path with params. Safari checks that the URL requested and the location returned are identical, otherwise it throws an 'Error during WebSocket handshake: location mismatch' error.
