### PR TITLE
Hardcoded em-websocket dependency

### DIFF
--- a/websocket-rack.gemspec
+++ b/websocket-rack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Rack-based WebSocket server}
 
   s.add_dependency 'rack'
-  s.add_dependency 'em-websocket', '~> 0.3.8'
+  s.add_dependency 'em-websocket', '>= 0.3.8'
   s.add_dependency 'eventmachine', '~> 1.0.0'
   s.add_dependency 'thin' # Temporary until we support more servers
 


### PR DESCRIPTION
As you can see: https://gemnasium.com/imanel/websocket-rack

The em-websocket dependency (~>0.3.8) is outdated. Here is my quick solution for that.
